### PR TITLE
Enable and update product index checks

### DIFF
--- a/app/code/community/Netresearch/Productvisibility/Helper/Data.php
+++ b/app/code/community/Netresearch/Productvisibility/Helper/Data.php
@@ -72,11 +72,10 @@ class Netresearch_Productvisibility_Helper_Data extends Mage_Core_Helper_Abstrac
             $this->getHasCategoryCheckpoint($product, $prefix); 
         $checkpoints[$prefix . 'is in stock'] = 
             $this->getIsInStockCheckpoint($product, $prefix);
-        // we can't determine if index is up to date in different Magento versions...
-        // $checkpoints[$prefix . 'is up to date in price index'] = 
-        //    $this->getIsUpToDateInPriceIndexCheckpoint($product, $prefix);
-        // $checkpoints[$prefix . 'is up to date in stock index'] = 
-        //    $this->getIsUpToDateInStockIndexCheckpoint($product, $prefix);
+        $checkpoints[$prefix . 'is up to date in price index'] =
+            $this->getIsUpToDateInPriceIndexCheckpoint($product, $prefix);
+        $checkpoints[$prefix . 'is up to date in stock index'] =
+            $this->getIsUpToDateInStockIndexCheckpoint($product, $prefix);
         $checkpoints[$prefix . 'should be visible'] = 
             $this->getShouldBeVisibleCheckpoint($product, $prefix);
         return $checkpoints;

--- a/app/code/community/Netresearch/Productvisibility/Helper/Product.php
+++ b/app/code/community/Netresearch/Productvisibility/Helper/Product.php
@@ -91,7 +91,7 @@ class Netresearch_Productvisibility_Helper_Product extends Mage_Core_Helper_Abst
             ->getConnection(Mage_Core_Model_Resource::DEFAULT_READ_RESOURCE);
         $select = $connection
             ->select()
-            ->from(Mage::getResourceModel('catalog/product_indexer_price')->getIdxTable())
+            ->from(Mage::getSingleton('core/resource')->getTableName('catalog/product_index_price'))
             ->where('customer_group_id = ?', 0)
             ->where('entity_id = ?', $product->getId());
 
@@ -135,7 +135,7 @@ class Netresearch_Productvisibility_Helper_Product extends Mage_Core_Helper_Abst
             ->getConnection(Mage_Core_Model_Resource::DEFAULT_READ_RESOURCE);
         $select = $connection
             ->select()
-            ->from(Mage::getResourceModel('cataloginventory/indexer_stock')->getIdxTable())
+            ->from(Mage::getSingleton('core/resource')->getTableName('cataloginventory/stock_status'))
             ->where('product_id = ?', $product->getId());
 
         $results = $connection->query($select)->fetchAll();


### PR DESCRIPTION
Because the database beneath the product price and stock status indexes hasn't really changed in recent versions, it seems worth breaking backwards compatibility to add back in that really very useful feature. I believe the stock status table has been around since at least version 1.3, and the product price index since 1.4.

Rather than querying the indexer, the code uses the Magento getTableName with the index table entity to determine the indexer table name.
